### PR TITLE
Merge staging to prod - Bump postgresql from 42.3.1 to 42.3.8 in /finish/module-persisting-da…

### DIFF
--- a/finish/module-persisting-data/pom.xml
+++ b/finish/module-persisting-data/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.1</version>
+            <version>42.3.8</version>
             <scope>provided</scope>
         </dependency>
         <!-- end::postgresql[] -->        
@@ -70,7 +70,7 @@
                             <dependency>
                                 <groupId>org.postgresql</groupId>
                                 <artifactId>postgresql</artifactId>
-                                <version>42.3.1</version>
+                                <version>42.3.8</version>
                             </dependency>
                         </dependencyGroup>
                     </copyDependencies>


### PR DESCRIPTION
…ta (#193)

Bumps [postgresql](https://github.com/pgjdbc/pgjdbc) from 42.3.1 to 42.3.8.
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/compare/REL42.3.1...REL42.3.8)

---
updated-dependencies:
- dependency-name: org.postgresql:postgresql dependency-type: direct:production ...