### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/finish/module-config/pom.xml
+++ b/finish/module-config/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/module-config/src/main/liberty/config/server.xml
+++ b/finish/module-config/src/main/liberty/config/server.xml
@@ -4,7 +4,7 @@
     <!-- Enable features -->
     <featureManager>
         <feature>jakartaee-10.0</feature>
-        <feature>microProfile-6.0</feature>
+        <feature>microProfile-6.1</feature>
     </featureManager>
 
     <!-- tag::httpPortVariable[] -->

--- a/finish/module-getting-started/pom.xml
+++ b/finish/module-getting-started/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/module-getting-started/src/main/liberty/config/server.xml
+++ b/finish/module-getting-started/src/main/liberty/config/server.xml
@@ -4,7 +4,7 @@
     <!-- Enable features -->
     <featureManager>
         <feature>jakartaee-10.0</feature>
-        <feature>microProfile-6.0</feature>
+        <feature>microProfile-6.1</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->

--- a/finish/module-jwt/pom.xml
+++ b/finish/module-jwt/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/module-jwt/src/main/liberty/config/server.xml
+++ b/finish/module-jwt/src/main/liberty/config/server.xml
@@ -3,7 +3,7 @@
 
     <featureManager>
         <feature>jakartaee-10.0</feature>
-        <feature>microProfile-6.0</feature>
+        <feature>microProfile-6.1</feature>
         <!-- tag::jwtSsoFeature[] -->
         <feature>jwtSso-1.0</feature>
         <!-- end::jwtSsoFeature[] -->

--- a/finish/module-kubernetes/src/main/liberty/config/server.xml
+++ b/finish/module-kubernetes/src/main/liberty/config/server.xml
@@ -3,7 +3,7 @@
 
     <featureManager>
         <feature>jakartaee-10.0</feature>
-        <feature>microProfile-6.0</feature>
+        <feature>microProfile-6.1</feature>
         <feature>jwtSso-1.0</feature>
     </featureManager>
 

--- a/finish/module-metrics/src/main/liberty/config/server.xml
+++ b/finish/module-metrics/src/main/liberty/config/server.xml
@@ -3,7 +3,7 @@
 
     <featureManager>
         <feature>jakartaee-10.0</feature>
-        <feature>microProfile-6.0</feature>
+        <feature>microProfile-6.1</feature>
         <feature>jwtSso-1.0</feature>
     </featureManager>
 

--- a/finish/module-openapi/pom.xml
+++ b/finish/module-openapi/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/module-openapi/src/main/liberty/config/server.xml
+++ b/finish/module-openapi/src/main/liberty/config/server.xml
@@ -5,7 +5,7 @@
     <featureManager>
         <feature>jakartaee-10.0</feature>
         <!-- tag::mp5[] -->
-        <feature>microProfile-6.0</feature>
+        <feature>microProfile-6.1</feature>
         <!-- end::mp5[] -->
     </featureManager>
 

--- a/finish/module-persisting-data/pom.xml
+++ b/finish/module-persisting-data/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/module-persisting-data/src/main/liberty/config/server.xml
+++ b/finish/module-persisting-data/src/main/liberty/config/server.xml
@@ -3,7 +3,7 @@
 
     <featureManager>
         <feature>jakartaee-10.0</feature>
-        <feature>microProfile-6.0</feature>
+        <feature>microProfile-6.1</feature>
     </featureManager>
 
     <variable name="http.port" defaultValue="9080" />

--- a/finish/module-securing/pom.xml
+++ b/finish/module-securing/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/module-securing/src/main/liberty/config/server.xml
+++ b/finish/module-securing/src/main/liberty/config/server.xml
@@ -3,7 +3,7 @@
 
     <featureManager>
         <feature>jakartaee-10.0</feature>
-        <feature>microProfile-6.0</feature>
+        <feature>microProfile-6.1</feature>
     </featureManager>
 
     <variable name="http.port" defaultValue="9080" />

--- a/finish/module-start/pom.xml
+++ b/finish/module-start/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/module-start/src/main/liberty/config/server.xml
+++ b/finish/module-start/src/main/liberty/config/server.xml
@@ -4,7 +4,7 @@
     <!-- Enable features -->
     <featureManager>
         <feature>jakartaee-10.0</feature>
-        <feature>microProfile-6.0</feature>
+        <feature>microProfile-6.1</feature>
     </featureManager>
 
     <!-- This template enables security. To get the full use of all the capabilities, a keystore and user registry are required. -->

--- a/finish/module-testcontainers/pom.xml
+++ b/finish/module-testcontainers/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/staging/module-config/pom.xml
+++ b/staging/module-config/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

