### PR TITLE
Merge staging to prod - Bump org.postgresql:postgresql from 42.7.1 to 42.7.2 in /finish/modul…

### DIFF
--- a/finish/module-jwt/pom.xml
+++ b/finish/module-jwt/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.1</version>
+            <version>42.7.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -71,7 +71,7 @@
                             <dependency>
                                 <groupId>org.postgresql</groupId>
                                 <artifactId>postgresql</artifactId>
-                                <version>42.7.1</version>
+                                <version>42.7.2</version>
                             </dependency>
                         </dependencyGroup>
                     </copyDependencies>

--- a/finish/module-persisting-data/pom.xml
+++ b/finish/module-persisting-data/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.6.0</version>
+            <version>42.7.2</version>
             <scope>provided</scope>
         </dependency>
         <!-- end::postgresql[] -->        

--- a/finish/module-securing/pom.xml
+++ b/finish/module-securing/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.1</version>
+            <version>42.7.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -67,7 +67,7 @@
                             <dependency>
                                 <groupId>org.postgresql</groupId>
                                 <artifactId>postgresql</artifactId>
-                                <version>42.7.1</version>
+                                <version>42.7.2</version>
                             </dependency>
                         </dependencyGroup>
                     </copyDependencies>

--- a/finish/module-testcontainers/pom.xml
+++ b/finish/module-testcontainers/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.1</version>
+            <version>42.7.2</version>
             <scope>provided</scope>
         </dependency>
         
@@ -138,7 +138,7 @@
                             <dependency>
                                 <groupId>org.postgresql</groupId>
                                 <artifactId>postgresql</artifactId>
-                                <version>42.7.1</version>
+                                <version>42.7.2</version>
                             </dependency>
                         </dependencyGroup>
                     </copyDependencies>


### PR DESCRIPTION
…e-securing (#227)

* Bump org.postgresql:postgresql in /finish/module-persisting-data

Bumps [org.postgresql:postgresql](https://github.com/pgjdbc/pgjdbc) from 42.6.0 to 42.7.2.
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/commits)

---
updated-dependencies:
- dependency-name: org.postgresql:postgresql dependency-type: direct:production ...



* Bump org.postgresql:postgresql in /finish/module-testcontainers

Bumps [org.postgresql:postgresql](https://github.com/pgjdbc/pgjdbc) from 42.7.1 to 42.7.2.
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/commits)

---
updated-dependencies:
- dependency-name: org.postgresql:postgresql dependency-type: direct:production ...



* Bump org.postgresql:postgresql in /finish/module-jwt

Bumps [org.postgresql:postgresql](https://github.com/pgjdbc/pgjdbc) from 42.7.1 to 42.7.2.
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/commits)

---
updated-dependencies:
- dependency-name: org.postgresql:postgresql dependency-type: direct:production ...



* Bump org.postgresql:postgresql in /finish/module-securing

Bumps [org.postgresql:postgresql](https://github.com/pgjdbc/pgjdbc) from 42.7.1 to 42.7.2.
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/commits)

---
updated-dependencies:
- dependency-name: org.postgresql:postgresql dependency-type: direct:production ...



---------