### PR TITLE
add  basicRegistry configuration to the server.xml 

### DIFF
--- a/finish/module-config/src/main/liberty/config/server.xml
+++ b/finish/module-config/src/main/liberty/config/server.xml
@@ -17,6 +17,12 @@
     <variable name="context.root" defaultValue="/inventory" />
     <!-- end::contextRootVariable[] -->
 
+    <basicRegistry id="basic" realm="BasicRealm">
+        <!--
+        <user name="yourUserName" password="" />
+        -->
+    </basicRegistry>
+
     <!-- To access this server from a remote client,
          add a host attribute to the following element, e.g. host="*" -->
     <!-- tag::editedHttpEndpoint[] -->

--- a/finish/module-getting-started/src/main/liberty/config/server.xml
+++ b/finish/module-getting-started/src/main/liberty/config/server.xml
@@ -7,6 +7,12 @@
         <feature>microProfile-6.1</feature>
     </featureManager>
 
+    <basicRegistry id="basic" realm="BasicRealm">
+        <!--
+        <user name="yourUserName" password="" />
+        -->
+    </basicRegistry>
+
     <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
     <httpEndpoint id="defaultHttpEndpoint"
                   httpPort="9080"

--- a/finish/module-openapi/src/main/liberty/config/server.xml
+++ b/finish/module-openapi/src/main/liberty/config/server.xml
@@ -9,6 +9,12 @@
         <!-- end::mp5[] -->
     </featureManager>
 
+    <basicRegistry id="basic" realm="BasicRealm">
+        <!--
+        <user name="yourUserName" password="" />
+        -->
+    </basicRegistry>
+
     <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
     <httpEndpoint id="defaultHttpEndpoint"
                   httpPort="9080"

--- a/finish/module-persisting-data/src/main/liberty/config/server.xml
+++ b/finish/module-persisting-data/src/main/liberty/config/server.xml
@@ -12,6 +12,12 @@
     <variable name="postgres/hostname" defaultValue="localhost" />
     <variable name="postgres/portnum" defaultValue="5432" />
 
+    <basicRegistry id="basic" realm="BasicRealm">
+        <!--
+        <user name="yourUserName" password="" />
+        -->
+    </basicRegistry>
+
     <httpEndpoint id="defaultHttpEndpoint" host="*"
                   httpPort="${http.port}" 
                   httpsPort="${https.port}" />

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -2,11 +2,17 @@
 <server description="inventory">
 
     <!-- Enable features -->
-  <featureManager>
-    <feature>appSecurity-5.0</feature>
-    <feature>restfulWS-3.1</feature>
-    <feature>mpJwt-2.1</feature>
-  </featureManager>
+    <featureManager>
+      <feature>appSecurity-5.0</feature>
+      <feature>restfulWS-3.1</feature>
+      <feature>mpJwt-2.1</feature>
+    </featureManager>
+
+    <basicRegistry id="basic" realm="BasicRealm">
+        <!--
+        <user name="yourUserName" password="" />
+        -->
+    </basicRegistry>
 
     <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
     <httpEndpoint id="defaultHttpEndpoint"


### PR DESCRIPTION
reduce error message from the dev mode console and liberty starter was updated to have the basicRegistry configuration in the server.xml 