### PR TITLE
Daily Build Fix for LTPA configuration errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,4 +80,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: server-logs
-          path: finish/target/liberty/wlp/usr/servers/defaultServer/logs/
+          path: finish/*/target/liberty/wlp/usr/servers/defaultServer/logs/**

--- a/finish/module-kubernetes/src/main/liberty/config/server.xml
+++ b/finish/module-kubernetes/src/main/liberty/config/server.xml
@@ -61,7 +61,11 @@
     <keyStore id="guideKeyStore"
               password="secret"
               location="${server.config.dir}/resources/security/key.p12" />
-
+    
+    <keyStore id="defaultKeyStore" password="secret"
+          location="${server.config.dir}/resources/security/key.p12" />
+    <ltpa keysPassword="secret" />
+    
     <jwtSso jwtBuilderRef="jwtInventoryBuilder"/>
     <jwtBuilder id="jwtInventoryBuilder" 
                 issuer="http://openliberty.io" 

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -25,6 +25,10 @@
     <keyStore id="guideKeyStore"
               password="secret"
               location="${server.config.dir}/resources/security/key.p12" />
+        
+    <keyStore id="defaultKeyStore" password="secret"
+          location="${server.config.dir}/resources/security/key.p12" />
+    <ltpa keysPassword="secret" />
     
     <!-- Configures the application on a specified context root -->
     <webApplication contextRoot="/system" location="system.war"/>


### PR DESCRIPTION
- Fix for daily build errors: Daily build fails on Open Liberty 26.0.0.4 because the servers fail to activate LTPA at startup as 26.0.0.4 version has removed the default LTPA keys password.
- Fix for test.yml : the logs to save to correct relevant locations 
